### PR TITLE
feat: update key in the traders response

### DIFF
--- a/bots/http/traders_handler.py
+++ b/bots/http/traders_handler.py
@@ -175,7 +175,8 @@ class Traders(Handler):
                 if trader_pub_key in parties_balances:
                     trader_balance = parties_balances[trader_pub_key]
 
-                traders[f"{market_id}_{wallet_name}"] = {
+                trader_key = f"{scenario}_{market_id}_{wallet_name}"
+                traders[trader_key] = {
                     "name": f"{market_id}_{wallet_name}",
                     "pubKey": trader_pub_key,
                     "parameters": {
@@ -198,13 +199,13 @@ class Traders(Handler):
                     public_key = scenario_wallet_state.keys[trader_pub_key].public_key
                     index = scenario_wallet_state.keys[trader_pub_key].index
 
-                traders[f"{market_id}_{wallet_name}"]["wallet"] = {
+                traders[trader_key]["wallet"] = {
                     "index": index,
                     "publicKey": public_key,
                 }
 
                 if scenario_wallet_state is not None and self._is_authenticated():
-                    traders[f"{market_id}_{wallet_name}"]["wallet"][
+                    traders[trader_key]["wallet"][
                         "recoveryPhrase"
                     ] = scenario_wallet_state.recovery_phrase
 


### PR DESCRIPTION
We created a mainnet-like market on the fairground. The mainnet market has two liquidity providers. 

<img width="795" alt="image" src="https://github.com/vegaprotocol/research-bots/assets/1239637/b4a51149-2e7e-4d73-b76d-a58205c6c486">


We wanted to create the same liquidity for Fairground, but there was one limitation how traders are reported for a top up.



# Changes

- Changed trader key from `{market_id}_{wallet_name}` to the `{scenario}_{market_id}_{wallet_name}`.


The `{scenario}` comes from the config. For example We have this line [`[scenario.mainnet_btcusdt_2]`](https://github.com/vegaprotocol/networks-internal/blob/main/fairground/research-bots-config.toml#L343), the scenario is `mainnet_btcusdt_2`. 

The previous output you can see on the [https://fairground.bots.vega.rocks/traders](https://fairground.bots.vega.rocks/traders):


```yaml
{
    "traders": {
        "54720823ebfad772c073de6e3157ac64081ab797f563317e85138a4e843daffd_market_maker": {
            "name": "54720823ebfad772c073de6e3157ac64081ab797f563317e85138a4e843daffd_market_maker",
            "pubKey": "31fbf2de9350027445c65108bf0f6ae96ac5242f2b7f90399f8ac60e8cb410f4",
            "parameters": {
                "marketBase": "BTC",
                "marketQuote": "USDT",
                "marketSettlementEthereumContractAddress": "0xdb10bF403771E44D0456F6C51EE655bb67AB05d9",
                "marketSettlementVegaAssetID": "8ba0b10971f0c4747746cd01ff05a53ae75ca91eba1d4d050b527910c983e27e",
                "wantedTokens": 200000,
                "balance": 487398.745726,
                "enableTopUp": true
            },
            "wallet": {
                "index": 3,
                "publicKey": "31fbf2de9350027445c65108bf0f6ae96ac5242f2b7f90399f8ac60e8cb410f4"
            }
        },
        "54720823ebfad772c073de6e3157ac64081ab797f563317e85138a4e843daffd_random_trader_0": {
            "name": "54720823ebfad772c073de6e3157ac64081ab797f563317e85138a4e843daffd_random_trader_0",
            "pubKey": "a828e121d8ba62e9474cefb70caa4ebcbbeb22c01af3343489a5ac8bd386de66",
```


The trader keys are: 

- `54720823ebfad772c073de6e3157ac64081ab797f563317e85138a4e843daffd_market_maker`
- `54720823ebfad772c073de6e3157ac64081ab797f563317e85138a4e843daffd_random_trader_0`

They will be:


- `mainnet_btcusdt_2_54720823ebfad772c073de6e3157ac64081ab797f563317e85138a4e843daffd_market_maker`
- `mainnet_btcusdt_2_54720823ebfad772c073de6e3157ac64081ab797f563317e85138a4e843daffd_random_trader_0`